### PR TITLE
[fix] Remedy KeyError that occurs when running validate_line_item_gp(…

### DIFF
--- a/eskill_custom/public/js/selling.js
+++ b/eskill_custom/public/js/selling.js
@@ -47,8 +47,10 @@ function validate_line_item_gp(frm) {
         frappe.call({
             method: "eskill_custom.api.validate_line_item_gp",
             args: {
+                doctype: frm.doctype,
+                exchange_rate: frm.doc.conversion_rate,
                 items: frm.doc.items,
-                exchange_rate: frm.doc.conversion_rate
+                new_doc: frm.is_new() ? true : false,
             },
             callback: (response) => {
                 if (response.message) {


### PR DESCRIPTION
…) on a new document due to the override_gp_limit field not being instantiated prior to the first save if the value is not set by a user.